### PR TITLE
add support for testnet & friendly shorter option using infura

### DIFF
--- a/myth
+++ b/myth
@@ -52,6 +52,10 @@ inputs.add_argument('--data', help='message call input data for tracing')
 
 options = parser.add_argument_group('options')
 options.add_argument('--sync-all', action='store_true', help='Also sync contracts with zero balance')
+options.add_argument('--infura-mainnet', type=bool, default=False, help='Use Infura Node service, default shorter setting equivalent to: --rpchost=mainnet.infura.io --rpcport=443 --rpctls="True"')
+options.add_argument('--infura-rinkeby', type=bool, default=False, help='Use Infura Node service, default shorter setting equivalent to: --rpchost=rinkeby.infura.io --rpcport=443 --rpctls="True"')
+options.add_argument('--infura-kovan', type=bool, default=False, help='Use Infura Node service, default shorter setting equivalent to: --rpchost=kovan.infura.io --rpcport=443 --rpctls="True"')
+options.add_argument('--infura-ropsten', type=bool, default=False, help='Use Infura Node service, default shorter setting equivalent to: --rpchost=ropsten.infura.io --rpcport=443 --rpctls="True"')
 options.add_argument('--rpchost', default='127.0.0.1', help='RPC host')
 options.add_argument('--rpcport', type=int, default=8545, help='RPC port')
 options.add_argument('--rpctls', type=bool, default=False, help='RPC port')
@@ -85,7 +89,16 @@ if (args.disassemble or args.graph or args.fire_lasers or args.xrefs):
                 exitWithError("Exception loading bytecode via IPC: " + str(e))
         else:
             try:
-                eth = EthJsonRpc(args.rpchost, args.rpcport, args.rpctls)
+                if args.infura_mainnet:
+                    eth = EthJsonRpc('mainnet.infura.io', 443, True) 
+                elif args.infura_rinkeby:
+                    eth = EthJsonRpc('rinkeby.infura.io', 443, True)
+                elif args.infura_kovan:
+                    eth = EthJsonRpc('kovan.infura.io', 443, True)
+                elif args.infura_ropsten:
+                    eth = EthJsonRpc('ropsten.infura.io', 443, True) 
+                else:
+                    eth = EthJsonRpc(args.rpchost, args.rpcport, args.rpctls)
 
                 encoded_bytecode = eth.eth_getCode(args.address)
 
@@ -144,7 +157,16 @@ elif (args.trace):
             encoded_bytecode = eth.eth_getCode(args.address)
 
         else:
-            eth = EthJsonRpc(args.rpchost, args.rpcport, args.rpctls)
+            if args.infura_mainnet:
+                    eth = EthJsonRpc('mainnet.infura.io', 443, True) 
+            elif args.infura_rinkeby:
+                eth = EthJsonRpc('rinkeby.infura.io', 443, True)
+            elif args.infura_kovan:
+                eth = EthJsonRpc('kovan.infura.io', 443, True)
+            elif args.infura_ropsten:
+                eth = EthJsonRpc('ropsten.infura.io', 443, True) 
+            else:
+                eth = EthJsonRpc(args.rpchost, args.rpcport, args.rpctls)
             encoded_bytecode = eth.eth_getCode(args.address)
 
     else:


### PR DESCRIPTION
Based on [PR #12 ](https://github.com/b-mueller/mythril/pull/12)
**2 main supports added**

1. Simpler/shorter command when using Infura Node service:
Support more user-friendly rpchost, rpctls setting by specifying `--infura-mainnet="True"` which is equivalently to setting the following three options one by one 
`--rpchost "mainnet.infura.io/{INFURA_KEY}" --rpcport "443" --rpctls="True"`

Namely, now to get opcode, use:
```shell
./myth --infura-mainnet="True" -d -a "0x2a0c0dbecc7e4d658f48e01e3fa353f44050c208"
```

2. Add testnet supports (rinkeby, kovan and ropsten)
For most projects, deployment and bug bounty program are on testnet. Therefore, I think adding testnet support is useful for code audit team. 
Also using infura node on testnet. An example to produce CFG of [this contract on Rinkeby](https://rinkeby.etherscan.io/address/0x0Eb437eA629d6e1f71f84a702A96CA4E0932f6f4#code) , use:
```shell
./myth --infura-rinkeby="True" -g "rinkeby_graph.html" -a "0x0Eb437eA629d6e1f71f84a702A96CA4E0932f6f4"
```

Cheers