### PR TITLE
corrected sync-all flag logic

### DIFF
--- a/mythril/ether/contractstorage.py
+++ b/mythril/ether/contractstorage.py
@@ -81,7 +81,7 @@ class ContractStorage(persistent.Persistent):
                         contract_code = eth.eth_getCode(contract_address)
                         contract_balance = eth.eth_getBalance(contract_address)
 
-                        if not contract_balance or sync_all:
+                        if not contract_balance and not sync_all:
                             # skip contracts with zero balance (disable with --sync-all)
                             continue
 


### PR DESCRIPTION
This corrects the bug where mythril skips all contracts if the `--sync-all` flag is used. 